### PR TITLE
dblatex: do not depend on PATH order, use HTTPS

### DIFF
--- a/Formula/dblatex.rb
+++ b/Formula/dblatex.rb
@@ -2,7 +2,7 @@ require_relative "../Library/MacTeXRequirement"
 
 class Dblatex < Formula
   desc "Transform DocBook XML to LaTeX"
-  homepage "http://dblatex.sourceforge.net"
+  homepage "https://dblatex.sourceforge.io"
   url "https://files.pythonhosted.org/packages/a8/1c/a07b54389399ac0c014c175936eb142f562468c607150a2df3e94d365611/dblatex-0.3.10.tar.bz2"
   sha256 "56fee45ef3c242c4800bad20c5aeb934b31ba0894bdf86275b60b2e7b2f4cb8e"
   license "GPL-2.0-or-later"
@@ -12,7 +12,7 @@ class Dblatex < Formula
 
   def install
     ENV.append_path "PATH", "/Library/TeX/texbin"
-    system "python", "setup.py", "install", "--prefix=#{prefix}"
+    system "/usr/bin/python", "setup.py", "install", "--prefix=#{prefix}"
     inreplace bin/"dblatex", "#!/usr/bin/env python", "#!/usr/bin/python"
   end
 


### PR DESCRIPTION
- Use the full path to the Python 2 executable so `brew install` works independently from the PATH order. This is helpful if `brew install` is called while a venv based on Python 3 is enabled.

- Use the canonical homepage URL and HTTPS according to `brew style`
